### PR TITLE
refactor: simplify `buffer` method

### DIFF
--- a/pages/api/webhooks.js
+++ b/pages/api/webhooks.js
@@ -12,21 +12,15 @@ export const config = {
   }
 };
 
-const buffer = (req) => {
-  return new Promise((resolve, reject) => {
-    const body = [];
-    req
-      .on('data', (chunk) => {
-        body.push(chunk);
-      })
-      .on('end', () => {
-        resolve(Buffer.concat(body));
-      })
-      .on('error', (err) => {
-        reject(err);
-      });
-  });
-};
+async function buffer(readable, encoding) {
+  const chunks = [];
+  for await (const chunk of readable) {
+    chunks.push(
+      typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk,
+    );
+  }
+  return Buffer.concat(chunks);
+}
 
 // TODO: deleted events and tax rate events?
 const relevantEvents = new Set([

--- a/pages/api/webhooks.js
+++ b/pages/api/webhooks.js
@@ -16,7 +16,7 @@ async function buffer(readable, encoding) {
   const chunks = [];
   for await (const chunk of readable) {
     chunks.push(
-      typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk,
+      typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk
     );
   }
   return Buffer.concat(chunks);

--- a/pages/api/webhooks.js
+++ b/pages/api/webhooks.js
@@ -12,11 +12,11 @@ export const config = {
   }
 };
 
-async function buffer(readable, encoding) {
+async function buffer(readable) {
   const chunks = [];
   for await (const chunk of readable) {
     chunks.push(
-      typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk
+      typeof chunk === "string" ? Buffer.from(chunk) : chunk
     );
   }
   return Buffer.concat(chunks);


### PR DESCRIPTION
According to the [API Routes docs](https://nextjs.org/docs/api-routes/introduction) of Next.js, `req` is an instance of [`http.IncomingMessage`](https://nodejs.org/api/http.html#http_class_http_incomingmessage), which extends [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable).

Readable streams can be [consumed with async iterators](https://nodejs.org/api/stream.html#stream_consuming_readable_streams_with_async_iterators) and thus, manual instantiation of a `Promise` isn’t required anymore.

For-await-of loops are [supported since Node 10.3.0](https://node.green/#ES2018-features-Asynchronous-Iterators-for-await-of-loops), so they should be safe to use nowadays.