### PR TITLE
Return 400 on webhook handler error

### DIFF
--- a/pages/api/webhooks.js
+++ b/pages/api/webhooks.js
@@ -85,7 +85,7 @@ const webhookHandler = async (req, res) => {
         }
       } catch (error) {
         console.log(error);
-        return res.json({ error: 'Webhook handler failed. View logs.' });
+        return res.status(400).send('Webhook error: "Webhook handler failed. View logs."');
       }
     }
 


### PR DESCRIPTION
Fix errors from webhooks firing out of order (eg. Stripe price before product).