### PR TITLE
fix: Prevent flash of footer on the account page

### DIFF
--- a/pages/account.js
+++ b/pages/account.js
@@ -27,8 +27,8 @@ export default function Account() {
   const { userLoaded, user, session, userDetails, subscription } = useUser();
 
   useEffect(() => {
-    if (!user) router.replace('/signin');
-  }, [user]);
+    if (userLoaded && !user) router.replace('/signin');
+  }, [user, userLoaded]);
 
   const redirectToCustomerPortal = async () => {
     setLoading(true);


### PR DESCRIPTION
Closes https://github.com/vercel/nextjs-subscription-payments/issues/45.

Fix the redirect when user is not load yet.

As can see in this video uploaded by @leerob.

https://user-images.githubusercontent.com/1596614/160066354-286131d0-46d8-4796-938a-89e9d570f43e.mp4


