### PR TITLE
Fix toDateTime calculation

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -38,7 +38,5 @@ export const postData = async ({
 };
 
 export const toDateTime = (secs: number) => {
-  var t = new Date('1970-01-01T00:30:00Z'); // Unix epoch start.
-  t.setSeconds(secs);
-  return t;
+  return new Date(secs * 1000);
 };


### PR DESCRIPTION
`toDateTime` was returning dates that are 30 minutes past the actual time in seconds.

No context for this decision was given in the commit that brought it in, so I figured it must be a bug.