### PR TITLE
fix(supabase): enable email confirmations to support PKCE

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,7 +56,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin`, `notion`, `twitch`,


### PR DESCRIPTION
https://github.com/supabase/auth-helpers/issues/562#issuecomment-1564158745

PKCE is the only flow that'll be supported moving forward and that needs to have `autoconfirm` disabled if we're using `@supabase/auth-helpers-nextjs`

Closes this issue too when email-password signup is used locally https://github.com/supabase/auth-helpers/issues/569