### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Next, start local webhook forwarding:
 ```bash
 stripe listen --forward-to=localhost:3000/api/webhooks
 ```
+If you have `trailingSlash: true` in your next.config.js please adjust url, the 308 will prevent webhook working:
+```bash
+stripe listen --forward-to=localhost:3000/api/webhooks/
+```
 
 Running this Stripe command will print a webhook secret (such as, `whsec_***`) to the console. Set `STRIPE_WEBHOOK_SECRET` to this value in your `.env.local` file.
 


### PR DESCRIPTION
Note about trailing slash on webhook.

Very easy to forget this is enabled and takes ages to work out why the sync between stripe and supabase isn't working