### PR TITLE
Fix Next.js header for Stripe webhook

### DIFF
--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -5,7 +5,6 @@ import {
   upsertPriceRecord,
   manageSubscriptionStatusChange
 } from '@/utils/supabase-admin';
-import { headers } from 'next/headers';
 
 const relevantEvents = new Set([
   'product.created',
@@ -20,7 +19,7 @@ const relevantEvents = new Set([
 
 export async function POST(req: Request) {
   const body = await req.text();
-  const sig = headers().get('Stripe-Signature') as string;
+  const sig = req.headers.get('stripe-signature') as string;
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   let event: Stripe.Event;
 


### PR DESCRIPTION
This solves the error: No signatures found matching the expected when using stripe webhook on Next.js
