### PR TITLE
fix stripe-webhooks route return type

### DIFF
--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
   let event: Stripe.Event;
 
   try {
-    if (!sig || !webhookSecret) return;
+    if (!sig || !webhookSecret) return new Response("Webhook secret not found.", { status: 400 })
     event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
   } catch (err: any) {
     console.log(`❌ Error message: ${err.message}`);


### PR DESCRIPTION
Not having a response returned in a route handler will cause a type error at build in Next.js 13.4.20, see https://github.com/vercel/next.js/pull/51394.