### PR TITLE
Handles unsupported Stripe events sent to webhook.

### DIFF
--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -75,6 +75,8 @@ export async function POST(req: Request) {
         }
       );
     }
+  } else {
+    return new Response(`Unsupported event type: ${event.type}`, { status: 400 });
   }
   return new Response(JSON.stringify({ received: true }));
 }


### PR DESCRIPTION
This commit adds and handler that throws and error when Stripe sends unsupported events to the applications webhook endpoint `<project-url/api/webhooks>`. The error messages can be obtained from the Vercel logs.

**Use case:**
I tried to delete products in Stripe and wondered why the Supabase DB wasn't reflecting the changes. I noticed that `app/webhooks/route.ts` doesn't support the Stripe event `product.deleted` when it is sent to the webhook. This commit adds a relevant error message, making it easier for users to debug such cases.

