### PR TITLE
Incorrectly converting stripe timestamps to DateTimes

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -40,7 +40,7 @@ export const postData = async ({
 };
 
 export const toDateTime = (secs: number) => {
-  var t = new Date('1970-01-01T00:30:00Z'); // Unix epoch start.
+  var t = new Date(+0); // Unix epoch start.
   t.setSeconds(secs);
   return t;
 };


### PR DESCRIPTION
Fixes https://github.com/vercel/nextjs-subscription-payments/issues/225 and https://github.com/vercel/nextjs-subscription-payments/issues/169.

Change Unix epoch start to `+0`