### PR TITLE
Fixes #269: Empty NEXT_PUBLIC_SITE_URL env var breaks checkout in local testing

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -4,8 +4,8 @@ type Price = Database['public']['Tables']['prices']['Row'];
 
 export const getURL = () => {
   let url =
-    (process.env.NEXT_PUBLIC_SITE_URL && process.env.NEXT_PUBLIC_SITE_URL.trim() !== '' ? process.env.NEXT_PUBLIC_SITE_URL :
-    process.env.NEXT_PUBLIC_VERCEL_URL && process.env.NEXT_PUBLIC_VERCEL_URL.trim() !== '' ? process.env.NEXT_PUBLIC_VERCEL_URL :
+    (process.env.NEXT_PUBLIC_SITE_URL && process.env.NEXT_PUBLIC_SITE_URL.trim() !== '' ? process.env.NEXT_PUBLIC_SITE_URL : // Set this to your site URL in production env.
+    process.env.NEXT_PUBLIC_VERCEL_URL && process.env.NEXT_PUBLIC_VERCEL_URL.trim() !== '' ? process.env.NEXT_PUBLIC_VERCEL_URL : // Automatically set by Vercel.
     'http://localhost:3000/').trim();
 
   // Make sure to include `https://` when not localhost.

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -3,15 +3,23 @@ import { Database } from '@/types_db';
 type Price = Database['public']['Tables']['prices']['Row'];
 
 export const getURL = () => {
-  let url =
-    (process.env.NEXT_PUBLIC_SITE_URL && process.env.NEXT_PUBLIC_SITE_URL.trim() !== '' ? process.env.NEXT_PUBLIC_SITE_URL : // Set this to your site URL in production env.
-    process.env.NEXT_PUBLIC_VERCEL_URL && process.env.NEXT_PUBLIC_VERCEL_URL.trim() !== '' ? process.env.NEXT_PUBLIC_VERCEL_URL : // Automatically set by Vercel.
-    'http://localhost:3000/').trim();
+  // Check if NEXT_PUBLIC_SITE_URL is set and non-empty. Set this to your site URL in production env.
+  let url = process?.env?.NEXT_PUBLIC_SITE_URL && process.env.NEXT_PUBLIC_SITE_URL.trim() !== ''
+    ? process.env.NEXT_PUBLIC_SITE_URL
+    : // If not set, check for NEXT_PUBLIC_VERCEL_URL, which is automatically set by Vercel.
+    process?.env?.NEXT_PUBLIC_VERCEL_URL && process.env.NEXT_PUBLIC_VERCEL_URL.trim() !== ''
+    ? process.env.NEXT_PUBLIC_VERCEL_URL
+    : // If neither is set, default to localhost for local development.
+    'http://localhost:3000/';
+
+  url = url.trim();
 
   // Make sure to include `https://` when not localhost.
   url = url.includes('http') ? url : `https://${url}`;
+
   // Make sure to include trailing `/`.
-  url = url.charAt(url.length - 1) === '/' ? url : `${url}/`;
+  url = url.endsWith('/') ? url : `${url}/`;
+
   return url;
 };
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -4,12 +4,13 @@ type Price = Database['public']['Tables']['prices']['Row'];
 
 export const getURL = () => {
   let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production env.
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
-    'http://localhost:3000/';
+    (process.env.NEXT_PUBLIC_SITE_URL && process.env.NEXT_PUBLIC_SITE_URL.trim() !== '' ? process.env.NEXT_PUBLIC_SITE_URL :
+    process.env.NEXT_PUBLIC_VERCEL_URL && process.env.NEXT_PUBLIC_VERCEL_URL.trim() !== '' ? process.env.NEXT_PUBLIC_VERCEL_URL :
+    'http://localhost:3000/').trim();
+
   // Make sure to include `https://` when not localhost.
   url = url.includes('http') ? url : `https://${url}`;
-  // Make sure to including trailing `/`.
+  // Make sure to include trailing `/`.
   url = url.charAt(url.length - 1) === '/' ? url : `${url}/`;
   return url;
 };

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -49,7 +49,7 @@ export const postData = async ({
 };
 
 export const toDateTime = (secs: number) => {
-  var t = new Date('1970-01-01T00:30:00Z'); // Unix epoch start.
+  const t = new Date('1970-01-01T00:30:00Z'); // Unix epoch start.
   t.setSeconds(secs);
   return t;
 };


### PR DESCRIPTION
The example .env.local file contains this text:

```
# Update this with your stable site URL only for the production environment.
NEXT_PUBLIC_SITE_URL=
```

If the user leaves this variable empty rather than deleting it, the template fails to create a checkout session during local testing. That's because getURL in 'helpers.ts' is only using the localhost fallback when NEXT_PUBLIC_SITE_URL is non-existent, not when it's empty.

This PR adds logic to go to the localhost fallback when the variable is empty.

Fixes #269. Also closes #236.