### PR TITLE
Fixes #248: Missing secret causes compile failure with '"Promise<Response \| undefined>" is not a valid POST return type'

### DIFF
--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
   let event: Stripe.Event;
 
   try {
-    if (!sig || !webhookSecret) return;
+    if (!sig || !webhookSecret) throw new Error("Missing Stripe Signature or Webhook Secret!");
     event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
   } catch (err: any) {
     console.log(`❌ Error message: ${err.message}`);


### PR DESCRIPTION
Throws an error in webhook route if secret is missing so that the error can be handled.

Fixes #248, closes #224, closes #244