### PR TITLE
Remove Next Server Warning Around Cookies

### DIFF
--- a/app/supabase-server.ts
+++ b/app/supabase-server.ts
@@ -3,9 +3,12 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { cache } from 'react';
 
-export const createServerSupabaseClient = cache(() =>
-  createServerComponentClient<Database>({ cookies })
-);
+export const createServerSupabaseClient = cache(() => {
+  const cookieStore = cookies();
+  return createServerComponentClient<Database>({
+    cookies: () => cookieStore,
+  });
+});
 
 export async function getSession() {
   const supabase = createServerSupabaseClient();


### PR DESCRIPTION
Fixes: https://nextjs.org/docs/messages/dynamic-server-error.

Was encountering:
```
Error: o [Error]: Dynamic server usage: Page couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error
  <...>
  digest: 'DYNAMIC_SERVER_USAGE'
}
```