### PR TITLE
Use full_name from user metadata Supabase Auth instead of users table.

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -11,11 +11,6 @@ export default async function Account() {
     data: { user }
   } = await supabase.auth.getUser();
 
-  const { data: userDetails } = await supabase
-    .from('users')
-    .select('*')
-    .single();
-
   const { data: subscription, error } = await supabase
     .from('subscriptions')
     .select('*, prices(*, products(*))')
@@ -44,7 +39,7 @@ export default async function Account() {
       </div>
       <div className="p-4">
         <CustomerPortalForm subscription={subscription} />
-        <NameForm userName={userDetails?.full_name ?? ''} />
+        <NameForm userName={user.user_metadata?.full_name ?? ''} />
         <EmailForm userEmail={user.email} />
       </div>
     </section>


### PR DESCRIPTION
NameForm.tsx is saving name changes using `updateName` function to supabase auth, not the database, hence the UI should display this value instead of the database value. Currently there is no sync between the two. 

Alternative solution would be to remake the updateName function to use database instead, but it seems like it was type on the account page side. 