### PR TITLE
Fix: webhook error

### DIFF
--- a/app/api/webhooks/route.ts
+++ b/app/api/webhooks/route.ts
@@ -7,6 +7,8 @@ import {
   deleteProductRecord,
   deletePriceRecord
 } from '@/utils/supabase/admin';
+import { NextRequest } from 'next/server';
+import { headers } from 'next/headers';
 
 const relevantEvents = new Set([
   'product.created',
@@ -21,9 +23,9 @@ const relevantEvents = new Set([
   'customer.subscription.deleted'
 ]);
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const body = await req.text();
-  const sig = req.headers.get('stripe-signature') as string;
+  const sig = headers().get('stripe-signature') as string;
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   let event: Stripe.Event;
 


### PR DESCRIPTION
Following the current project, when I deploy to Vercel and the webhook is triggered, the following error is displayed:

```
❌ Error message: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe? 
 If a webhook request is being forwarded by a third-party tool, ensure that the exact request body, including JSON formatting and new line style, is preserved.

Learn more about webhook signing and explore webhook integration examples for various frameworks at https://github.com/stripe/stripe-node#webhook-signing
```

Reading the [documentation](https://github.com/stripe/stripe-node#webhook-signing), I discovered that it could be related to the payload passed to the `stripe.webhooks.constructEvent()` function.

Currently:

```js
...
export async function POST(req: Request) {
	const body = await req.text();
	const sig = req.headers.get('stripe-signature') as string;
	const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
	let event: Stripe.Event;
	
	try {
		if (!sig || !webhookSecret)
			return new Response('Webhook secret not found.', { status: 400 });
			
		event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
		console.log(`🔔 Webhook received: ${event.type}`);
	} catch (err: any) {
		console.log(`❌ Error message: ${err.message}`);
		return new Response(`Webhook Error: ${err.message}`, { status: 400 });
	}
...
```

Solution:

```js
...
import { NextRequest } from 'next/server';
import { headers } from 'next/headers';

export async function POST(req: NextRequest) {
	const body = await req.text();
	const sig = headers().get('stripe-signature') as string;
...
```

I changed the request type to [`NextRequest`](https://nextjs.org/docs/app/api-reference/functions/next-request), and also used [`headers`](https://nextjs.org/docs/app/api-reference/functions/headers) from Next for reading the header. With this change, I finally achieved success.

Note: When tested locally with [Stripe CLI](https://docs.stripe.com/stripe-cli), it works perfectly; the error only occurs when deployed.