### PR TITLE
update supbase:reset/pull/push commands in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "supabase:stop": "npx supabase stop",
     "supabase:status": "npx supabase status",
     "supabase:restart": "npm run supabase:stop && npm run supabase:start",
-    "supabase:reset": "npx supabase reset",
+    "supabase:reset": "npx supabase db reset",
     "supabase:link": "npx supabase link",
     "supabase:generate-types": "npx supabase gen types typescript --local --schema public > types_db.ts",
     "supabase:generate-migration": "npx supabase db diff | npx supabase migration new",
     "supabase:generate-seed": "npx supabase db dump --data-only -f supabase/seed.sql",
-    "supabase:push": "npx supabase push",
-    "supabase:pull": "npx supabase pull"
+    "supabase:push": "npx supabase db push",
+    "supabase:pull": "npx supabase db pull"
   },
   "dependencies": {
     "@radix-ui/react-toast": "^1.1.5",


### PR DESCRIPTION
Current supabase cli version 1.153.4 pull, push, and reset commands are invoked with `supabase db <action>`.

Updated the package.json to use this new syntax.