### PR TITLE
Added/Fix Lifetime option

### DIFF
--- a/components/ui/Pricing/Pricing.tsx
+++ b/components/ui/Pricing/Pricing.tsx
@@ -30,7 +30,7 @@ interface Props {
   subscription: SubscriptionWithProduct | null;
 }
 
-type BillingInterval = 'lifetime' | 'year' | 'month';
+type BillingInterval = null | 'year' | 'month';
 
 export default function Pricing({ user, products, subscription }: Props) {
   const intervals = Array.from(
@@ -141,6 +141,19 @@ export default function Pricing({ user, products, subscription }: Props) {
                   Yearly billing
                 </button>
               )}
+              {intervals.includes(null) && (
+                <button
+                  onClick={() => setBillingInterval(null)}
+                  type="button"
+                  className={`${
+                    billingInterval === null
+                      ? 'relative w-1/2 bg-zinc-700 border-zinc-800 shadow-sm text-white'
+                      : 'ml-0.5 relative w-1/2 border border-transparent text-zinc-400'
+                  } rounded-md m-1 py-2 text-sm font-medium whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-opacity-50 focus:z-10 sm:w-auto sm:px-8`}
+                >
+                  Lifetime
+                </button>
+              )}
             </div>
           </div>
           <div className="mt-12 space-y-4 sm:mt-16 sm:space-y-0 flex flex-wrap justify-center gap-6 lg:max-w-4xl lg:mx-auto xl:max-w-none xl:mx-0">
@@ -179,7 +192,7 @@ export default function Pricing({ user, products, subscription }: Props) {
                         {priceString}
                       </span>
                       <span className="text-base font-medium text-zinc-100">
-                        /{billingInterval}
+                        {billingInterval !== null && `/${billingInterval}`}
                       </span>
                     </p>
                     <Button


### PR DESCRIPTION
- type BillingInterval contained 'lifetime' option when stripe does not offer a 'lifetime' interval. 
- worked around this issue by creating a one-time payment option on the product which would have a 'null' interval value on the database. Work with this to set the 'lifetime' value to null
Database value:
![image](https://github.com/vercel/nextjs-subscription-payments/assets/98991855/aeff8ad0-d4c8-4f8a-9576-5b2494a1ce12)
Result:
- ![image](https://github.com/vercel/nextjs-subscription-payments/assets/98991855/b5d4fb9a-9486-4717-9309-5effd71366f8)