### PR TITLE
Fixing ugly Y offset on small screen sizes

### DIFF
--- a/components/ui/Pricing/Pricing.tsx
+++ b/components/ui/Pricing/Pricing.tsx
@@ -143,7 +143,7 @@ export default function Pricing({ user, products, subscription }: Props) {
               )}
             </div>
           </div>
-          <div className="mt-12 space-y-4 sm:mt-16 sm:space-y-0 flex flex-wrap justify-center gap-6 lg:max-w-4xl lg:mx-auto xl:max-w-none xl:mx-0">
+          <div className="mt-12 space-y-0 sm:mt-16 flex flex-wrap justify-center gap-6 lg:max-w-4xl lg:mx-auto xl:max-w-none xl:mx-0">
             {products.map((product) => {
               const price = product?.prices?.find(
                 (price) => price.interval === billingInterval


### PR DESCRIPTION
While using this template I found a trivial but unsightly issue with the alignment of the pricing options when the screen was between xs and sm.

<img width="622" alt="Screenshot 2024-05-11 at 11 41 20 PM" src="https://github.com/vercel/nextjs-subscription-payments/assets/11167066/77993128-9e9a-49aa-8a3d-6809d4670f65">
