### PR TITLE
Updating supabase middleware away from deprecated createServerClient method

### DIFF
--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,4 +1,4 @@
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { createServerClient, type CookieMethodsServer } from '@supabase/ssr';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export const createClient = (request: NextRequest) => {
@@ -14,46 +14,19 @@ export const createClient = (request: NextRequest) => {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value;
+        getAll() {
+          return request.cookies.getAll()
         },
-        set(name: string, value: string, options: CookieOptions) {
-          // If the cookie is updated, update the cookies for the request and response
-          request.cookies.set({
-            name,
-            value,
-            ...options
-          });
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           response = NextResponse.next({
-            request: {
-              headers: request.headers
-            }
-          });
-          response.cookies.set({
-            name,
-            value,
-            ...options
-          });
+            request
+          })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options)
+          )
         },
-        remove(name: string, options: CookieOptions) {
-          // If the cookie is removed, update the cookies for the request and response
-          request.cookies.set({
-            name,
-            value: '',
-            ...options
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers
-            }
-          });
-          response.cookies.set({
-            name,
-            value: '',
-            ...options
-          });
-        }
-      }
+      } as CookieMethodsServer
     }
   );
 

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,4 +1,4 @@
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { createServerClient, type CookieMethodsServer } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { Database } from '@/types_db';
 
@@ -15,29 +15,20 @@ export const createClient = () => {
     // Define a cookies object with methods for interacting with the cookie store and pass it to the client
     {
       cookies: {
-        // The get method is used to retrieve a cookie by its name
-        get(name: string) {
-          return cookieStore.get(name)?.value;
+        // The getAll method is used to cookies by name
+        getAll() {
+          return cookieStore.getAll()
         },
-        // The set method is used to set a cookie with a given name, value, and options
-        set(name: string, value: string, options: CookieOptions) {
+        // The setAll method is used to cookies with a given name, value, and options
+        setAll(cookiesToSet) {
           try {
-            cookieStore.set({ name, value, ...options });
+            cookiesToSet.forEach(({ name, value }) => cookieStore.set(name, value))
           } catch (error) {
             // If the set method is called from a Server Component, an error may occur
             // This can be ignored if there is middleware refreshing user sessions
           }
-        },
-        // The remove method is used to delete a cookie by its name
-        remove(name: string, options: CookieOptions) {
-          try {
-            cookieStore.set({ name, value: '', ...options });
-          } catch (error) {
-            // If the remove method is called from a Server Component, an error may occur
-            // This can be ignored if there is middleware refreshing user sessions
-          }
         }
-      }
+      } as CookieMethodsServer
     }
   );
 };


### PR DESCRIPTION
The Supabase team has published the recommended replacement code, which I'm transplanting over here.  See https://github.com/supabase/supabase/blob/e77f8b9f398a8436aa37f93b443620081211e1bc/apps/docs/content/guides/auth/server-side/nextjs.mdx?plain=1#L221-L283

Solves https://github.com/vercel/nextjs-subscription-payments/issues/358