### PR TITLE
Adding + as valid character in email validator regex

### DIFF
--- a/utils/auth-helpers/server.ts
+++ b/utils/auth-helpers/server.ts
@@ -7,7 +7,7 @@ import { getURL, getErrorRedirect, getStatusRedirect } from 'utils/helpers';
 import { getAuthTypes } from 'utils/auth-helpers/settings';
 
 function isValidEmail(email: string) {
-  var regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
+  var regex = /^[a-zA-Z0-9\+._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
   return regex.test(email);
 }
 


### PR DESCRIPTION
This was rejecting valid emails, i.e. user+extrastuff@gmail.com